### PR TITLE
Bump Flask to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.1.0
 Pillow==9.2.0
 pillow_heif==0.5.0
 protobuf==4.21.4


### PR DESCRIPTION
The Flask from requirements.txt (1.1.2) returns a `ImportError: cannot import name 'escape' from 'jinja2'` error - Bumping it to 2.1.0 should fix the issue